### PR TITLE
Members are determined from context.

### DIFF
--- a/src/CodeModel.cpp
+++ b/src/CodeModel.cpp
@@ -81,7 +81,7 @@ private:
 	virtual bool visit(VariableDeclaration const& _node) override
 	{
 		SolidityDeclaration decl;
-		decl.type = CodeModel::nodeType(_node.type(nullptr).get());
+		decl.type = CodeModel::nodeType(_node.type().get());
 		decl.name = QString::fromStdString(_node.name());
 		decl.slot = 0;
 		decl.offset = 0;
@@ -133,7 +133,7 @@ QHash<unsigned, SolidityDeclarations> collectStorage(dev::solidity::ContractDefi
 		dev::solidity::VariableDeclaration const* declaration = std::get<0>(v);
 		dev::u256 slot = std::get<1>(v);
 		unsigned offset = std::get<2>(v);
-		result[static_cast<unsigned>(slot)].push_back(SolidityDeclaration { QString::fromStdString(declaration->name()), CodeModel::nodeType(declaration->type(nullptr).get()), slot, offset });
+		result[static_cast<unsigned>(slot)].push_back(SolidityDeclaration { QString::fromStdString(declaration->name()), CodeModel::nodeType(declaration->type().get()), slot, offset });
 	}
 	return result;
 }
@@ -624,7 +624,7 @@ SolidityType CodeModel::nodeType(dev::solidity::Type const* _type)
 	{
 		r.type = SolidityType::Type::Struct;
 		StructType const* s = dynamic_cast<StructType const*>(_type);
-		for(auto const& structMember: s->members())
+		for(auto const& structMember: s->members(nullptr))
 		{
 			auto slotAndOffset = s->storageOffsetsOfMember(structMember.name);
 			r.members.push_back(SolidityDeclaration { QString::fromStdString(structMember.name), nodeType(structMember.type.get()), slotAndOffset.first, slotAndOffset.second });

--- a/src/QContractDefinition.cpp
+++ b/src/QContractDefinition.cpp
@@ -43,7 +43,7 @@ QContractDefinition::QContractDefinition(QObject* _parent, dev::solidity::Contra
 		m_functions.append(new QFunctionDefinition(parent, it.second));
 
 	for (auto const& it: _contract->events())
-		m_events.append(new QFunctionDefinition(parent, it));
+		m_events.append(new QFunctionDefinition(parent, *it));
 
 }
 

--- a/src/QFunctionDefinition.cpp
+++ b/src/QFunctionDefinition.cpp
@@ -34,21 +34,21 @@ QFunctionDefinition::QFunctionDefinition(QObject* _parent, dev::solidity::Functi
 	init(_f);
 }
 
-QFunctionDefinition::QFunctionDefinition(QObject* _parent, ASTPointer<FunctionDefinition> const& _f): QBasicNodeDefinition(_parent, _f.get()), m_hash(dev::sha3(_f->externalSignature())),
-	m_fullHash(dev::sha3(_f->externalSignature()))
+QFunctionDefinition::QFunctionDefinition(QObject* _parent, FunctionDefinition const& _f): QBasicNodeDefinition(_parent, &_f), m_hash(dev::sha3(_f.externalSignature())),
+	m_fullHash(dev::sha3(_f.externalSignature()))
 {
-	for (unsigned i = 0; i < _f->parameters().size(); ++i)
-		m_parameters.append(new QVariableDeclaration(parent(), _f->parameters().at(i)));
+	for (unsigned i = 0; i < _f.parameters().size(); ++i)
+		m_parameters.append(new QVariableDeclaration(parent(), _f.parameters().at(i)));
 
-	for (unsigned i = 0; i < _f->returnParameters().size(); ++i)
-		m_returnParameters.append(new QVariableDeclaration(parent(), _f->returnParameters().at(i)));
+	for (unsigned i = 0; i < _f.returnParameters().size(); ++i)
+		m_returnParameters.append(new QVariableDeclaration(parent(), _f.returnParameters().at(i)));
 }
 
-QFunctionDefinition::QFunctionDefinition(QObject* _parent, ASTPointer<dev::solidity::EventDefinition> const& _e): QBasicNodeDefinition(_parent, _e.get())
+QFunctionDefinition::QFunctionDefinition(QObject* _parent, dev::solidity::EventDefinition const& _e): QBasicNodeDefinition(_parent, &_e)
 {
-	for (unsigned i = 0; i < _e->parameters().size(); ++i)
-		m_parameters.append(new QVariableDeclaration(parent(), _e->parameters().at(i)));
-	FunctionTypePointer _f = std::make_shared<FunctionType>(*_e);
+	for (unsigned i = 0; i < _e.parameters().size(); ++i)
+		m_parameters.append(new QVariableDeclaration(parent(), _e.parameters().at(i)));
+	FunctionTypePointer _f = std::make_shared<FunctionType>(_e);
 	m_hash = (FixedHash<4>)dev::sha3(_f->externalSignature());
 	m_fullHash = dev::sha3(_f->externalSignature());
 }

--- a/src/QFunctionDefinition.h
+++ b/src/QFunctionDefinition.h
@@ -41,8 +41,8 @@ public:
 	QFunctionDefinition(){}
 	QFunctionDefinition(QObject* _parent): QBasicNodeDefinition(_parent) {}
 	QFunctionDefinition(QObject* _parent, solidity::FunctionTypePointer const& _f);
-	QFunctionDefinition(QObject* _parent, solidity::ASTPointer<solidity::EventDefinition> const& _f);
-	QFunctionDefinition(QObject* _parent, solidity::ASTPointer<solidity::FunctionDefinition> const& _f);
+	QFunctionDefinition(QObject* _parent, solidity::EventDefinition const& _f);
+	QFunctionDefinition(QObject* _parent, solidity::FunctionDefinition const& _f);
 	/// Init members
 	void init(dev::solidity::FunctionTypePointer _f);
 	/// Get all input parameters of this function.

--- a/src/QVariableDeclaration.cpp
+++ b/src/QVariableDeclaration.cpp
@@ -33,7 +33,7 @@ namespace mix
 
 QVariableDeclaration::QVariableDeclaration(QObject* _parent, ASTPointer<VariableDeclaration> const _v):
 	QBasicNodeDefinition(_parent, _v.get()),
-	m_type(new QSolidityType(this, CodeModel::nodeType(_v->type(nullptr).get()))), m_isIndexed(_v->isIndexed())
+	m_type(new QSolidityType(this, CodeModel::nodeType(_v->type().get()))), m_isIndexed(_v->isIndexed())
 {
 }
 


### PR DESCRIPTION
DEPENDS:
{
"solidity": "refactor"
}
