### PR TITLE
default block gas limit changed

### DIFF
--- a/src/MixClient.cpp
+++ b/src/MixClient.cpp
@@ -64,7 +64,7 @@ ChainParams MixBlockChain::createParams(AccountMap const& _pre)
 	ret.author = Address();
 	ret.blockReward = 5000 * ether;
 	ret.difficulty = 0;
-	ret.gasLimit = 3141592;
+	ret.gasLimit = DefaultBlockGasLimit;
 	ret.gasUsed = 0;
 	ret.genesisState = _pre;
 	ret.maximumExtraDataSize = 1024;


### PR DESCRIPTION
moved from https://github.com/ethereum/mix/pull/275

depends on 
https://github.com/ethereum/libethereum/pull/205
