### PR TITLE
Reflect Type Name and Category changes for solidity

### DIFF
--- a/src/CodeModel.cpp
+++ b/src/CodeModel.cpp
@@ -807,12 +807,12 @@ SolidityType CodeModel::nodeType(dev::solidity::Type const* _type)
 	}
 		break;
 	case Type::Category::Function:
-	case Type::Category::IntegerConstant:
+	case Type::Category::RationalNumber:
 	case Type::Category::StringLiteral:
 	case Type::Category::Magic:
 	case Type::Category::Mapping:
 	case Type::Category::Modifier:
-	case Type::Category::Real:
+	case Type::Category::FixedPoint:
 	case Type::Category::TypeType:
 	case Type::Category::Tuple:
 	default:


### PR DESCRIPTION
In accordance with the arrival of the fixed point type, the solidity team has made a few changes to some of the category names. Jenkins will not let us pass until these changes are made. So I've laid out here what needs changing. Once we are ready to merge, these changes should be applied. Thank you. 
