### PR TITLE
Readme: Link directly to build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ Download binaries:
     https://github.com/ethereum/mix/releases
     
 Build from source:
-    https://github.com/ethereum/webthree-umbrella/wiki
+    http://www.ethdocs.org/en/latest/ethereum-clients/cpp-ethereum/building-from-source/
 


### PR DESCRIPTION
There were a couple unnecessary indirection pages in between.

Seem reasonable?
