### PR TITLE
Updated version to 1.0.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ include(EthPolicy)
 eth_policy()
 
 # project name and version should be set after cmake_policy CMP0048
-set(PROJECT_VERSION "1.0.4")
+set(PROJECT_VERSION "1.0.5")
 project(mix VERSION ${PROJECT_VERSION})
 
 # Let's find our dependencies


### PR DESCRIPTION
Changes since 1.0.4:
- Improved handling and error messages for creation of projects in existing folders.
- Fixed documentation link
- (in webthree-helpers) Switched OS X pre-built binaries to Debug to work around crash-at-boot issue.
